### PR TITLE
Release v1.0.1: Update travis build and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: go
 # in the next version of Go. Don't worry! Later we declare that test runs
 # are allowed to fail on Go tip.
 go:
-  - 1.10
+  - 1.10.x
   - master
 
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,8 @@ dep:
 	@misc/scripts/deps-ensure
 	@dep ensure -v
 
+fmt:
+	@go fmt ./...
+
 test:
-	@go test -v ./pkg/...
+	@go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # go-artifactory #
 go-artifactory is a Go client library for accessing the [Artifactory API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API)
 
-go-artifactory is tested on Go version 1.9
+## Requirements ##
+- Go version 1.9+
+- Dep is used for dependency management
 
 ## Usage ##
 ```go

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # go-artifactory #
 go-artifactory is a Go client library for accessing the [Artifactory API](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API)
 
+[![Build Status](https://travis-ci.org/atlassian/go-artifactory.svg?branch=master)](https://travis-ci.org/atlassian/go-artifactory)
+
 ## Requirements ##
 - Go version 1.9+
 - Dep is used for dependency management

--- a/misc/hooks/pre-commit
+++ b/misc/hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-go fmt ./pkg/...
+go fmt  ./...
 
 # re-add formatted files
 for file in `git diff --cached --name-only`
@@ -8,4 +8,4 @@ do
 	git add $file
 done
 
-go test -v ./pkg/...
+go test -v -race ./...


### PR DESCRIPTION
- Uses correct Go version in travis build
- Added build status to docs
- Improved various scripts and docs