### PR TITLE
In the event that v is nil, the function should allow the caller to c…

### DIFF
--- a/pkg/artifactory/artifactory.go
+++ b/pkg/artifactory/artifactory.go
@@ -180,7 +180,6 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	err = checkResponse(resp)
 	if err != nil {
@@ -198,6 +197,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 				err = nil // ignore EOF errors caused by empty response body
 			}
 		}
+		resp.Body.Close()
 	}
 
 	return resp, err

--- a/pkg/artifactory/artifactory_test.go
+++ b/pkg/artifactory/artifactory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -51,4 +52,24 @@ func TestTokenAuthTransport(t *testing.T) {
 
 	_, _, err = client.System.Ping(context.Background())
 	assert.Nil(t, err)
+}
+
+func TestDo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("Hello World"))
+	}))
+
+	client, err := NewClient(server.URL, nil)
+	assert.Nil(t, err)
+
+	request, err := client.NewRequest(http.MethodGet, "", nil)
+	assert.Nil(t, err)
+
+	resp, err := client.Do(context.TODO(), request, nil)
+	assert.Nil(t, err)
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello World", string(body))
+	defer resp.Body.Close()
 }


### PR DESCRIPTION
…lose the response body so that it can be manually parsed

Fixes https://github.com/atlassian/go-artifactory/issues/4