### PR TITLE
Add nuget configuration to V1 RemoteRepository

### DIFF
--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -153,6 +153,12 @@ type ContentSynchronisation struct {
 	Source     *Source     `json:"source,omitempty"`
 }
 
+type Nuget struct {
+	FeedContextPath     *string `json:"feedContextPath,omitempty"`
+	DownloadContextPath *string `json:"downloadContextPath,omitempty"`
+	V3FeedUrl           *string `json:"v3FeedUrl,omitempty"`
+}
+
 type RemoteRepository struct {
 	Key                               *string                 `json:"key,omitempty"`
 	RClass                            *string                 `json:"rclass,omitempty"` // Mandatory element in create/replace queries (optional in "update" queries)
@@ -201,6 +207,7 @@ type RemoteRepository struct {
 	MaxUniqueTags                     *int                    `json:"maxUniqueTags,omitempty"`
 	MismatchingMimeTypesOverrideList  *string                 `json:"mismatchingMimeTypesOverrideList,omitempty"`
 	MissedRetrievalCachePeriodSecs    *int                    `json:"missedRetrievalCachePeriodSecs,omitempty"`
+	Nuget                             *Nuget                  `json:"nuget,omitempty"`
 	Offline                           *bool                   `json:"offline,omitempty"`
 	Password                          *string                 `json:"password,omitempty"`
 	PropagateQueryParams              *bool                   `json:"propagateQueryParams,omitempty"`


### PR DESCRIPTION
Needed for atlassian/terraform-provider-artifactory#34

Adding in the newly documented Nuget configuration for Remote repositories so I can add it to the terraform provider.

I _think_ this is all I need to do in this repo, let me know if anything else is needed.