### PR TITLE
Fix nuget config after API change

### DIFF
--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -153,6 +153,12 @@ type ContentSynchronisation struct {
 	Source     *Source     `json:"source,omitempty"`
 }
 
+type Nuget struct {
+	FeedContextPath     *string `json:"feedContextPath,omitempty"`
+	DownloadContextPath *string `json:"downloadContextPath,omitempty"`
+	V3FeedUrl           *string `json:"v3FeedUrl,omitempty"`
+}
+
 type RemoteRepository struct {
 	Key                               *string                 `json:"key,omitempty"`
 	RClass                            *string                 `json:"rclass,omitempty"` // Mandatory element in create/replace queries (optional in "update" queries)
@@ -227,9 +233,12 @@ type RemoteRepository struct {
 	VcsGitDownloadUrl                 *string                 `json:"vcsGitDownloadUrl,omitempty"`
 	ClientTLSCertificate              *string                 `json:"clientTlsCertificate,omitempty"`
 	PyPiRegistryUrl                   *string                 `json:"pyPiRegistryUrl,omitempty"`
-	FeedContextPath                   *string                 `json:"feedContextPath,omitempty"`
-	DownloadContextPath               *string                 `json:"downloadContextPath,omitempty"`
-	V3FeedUrl                         *string                 `json:"v3FeedUrl,omitempty"`
+	// Deprecated since 6.9. Replaced with fields FeedContextPath, DownloadContextPath, V3FeedUrl below
+	Nuget *Nuget `json:"nuget,omitempty"`
+	// Replaces Nuget struct since 6.9. Mutually exclusive with Nuget field
+	FeedContextPath     *string `json:"feedContextPath,omitempty"`
+	DownloadContextPath *string `json:"downloadContextPath,omitempty"`
+	V3FeedUrl           *string `json:"v3FeedUrl,omitempty"`
 }
 
 func (r RemoteRepository) String() string {

--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -153,12 +153,6 @@ type ContentSynchronisation struct {
 	Source     *Source     `json:"source,omitempty"`
 }
 
-type Nuget struct {
-	FeedContextPath     *string `json:"feedContextPath,omitempty"`
-	DownloadContextPath *string `json:"downloadContextPath,omitempty"`
-	V3FeedUrl           *string `json:"v3FeedUrl,omitempty"`
-}
-
 type RemoteRepository struct {
 	Key                               *string                 `json:"key,omitempty"`
 	RClass                            *string                 `json:"rclass,omitempty"` // Mandatory element in create/replace queries (optional in "update" queries)
@@ -207,7 +201,6 @@ type RemoteRepository struct {
 	MaxUniqueTags                     *int                    `json:"maxUniqueTags,omitempty"`
 	MismatchingMimeTypesOverrideList  *string                 `json:"mismatchingMimeTypesOverrideList,omitempty"`
 	MissedRetrievalCachePeriodSecs    *int                    `json:"missedRetrievalCachePeriodSecs,omitempty"`
-	Nuget                             *Nuget                  `json:"nuget,omitempty"`
 	Offline                           *bool                   `json:"offline,omitempty"`
 	Password                          *string                 `json:"password,omitempty"`
 	PropagateQueryParams              *bool                   `json:"propagateQueryParams,omitempty"`
@@ -234,6 +227,9 @@ type RemoteRepository struct {
 	VcsGitDownloadUrl                 *string                 `json:"vcsGitDownloadUrl,omitempty"`
 	ClientTLSCertificate              *string                 `json:"clientTlsCertificate,omitempty"`
 	PyPiRegistryUrl                   *string                 `json:"pyPiRegistryUrl,omitempty"`
+	FeedContextPath                   *string                 `json:"feedContextPath,omitempty"`
+	DownloadContextPath               *string                 `json:"downloadContextPath,omitempty"`
+	V3FeedUrl                         *string                 `json:"v3FeedUrl,omitempty"`
 }
 
 func (r RemoteRepository) String() string {


### PR DESCRIPTION
JFrog made an undocumented API change in 6.9 that has broken the nuget configuration, the configuration is no longer nested under the `nuget` object.

I've sent them a ticket requesting that they update the documentation.