### PR TITLE
bugfix: Parameter of ChangePassword() 

### DIFF
--- a/artifactory/v1/security.go
+++ b/artifactory/v1/security.go
@@ -210,7 +210,7 @@ func (s *SecurityService) UnexpireUserPassword(ctx context.Context, username str
 }
 
 type PasswordChangeOptions struct {
-	Username     *string `json:"username,omitempty"`
+	Username     *string `json:"userName,omitempty"`
 	OldPassword  *string `json:"oldPassword,omitempty"`
 	NewPassword1 *string `json:"newPassword1,omitempty"`
 	NewPassword2 *string `json:"newPassword2,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atlassian/go-artifactory/v2
+module github.com/janggwan-im/go-artifactory/v2
 
 require (
 	github.com/google/go-querystring v1.0.0


### PR DESCRIPTION
The field "username" in the json body should be "userName" to properly work.
Otherwise, we will get the response "400 [{Status:400 Message:Username cannot be empty}]"

