### PR TITLE
support for accessing artifacts and their metadata

### DIFF
--- a/artifactory/v1/artifacts.go
+++ b/artifactory/v1/artifacts.go
@@ -226,7 +226,7 @@ func (s *ArtifactService) FileInfo(ctx context.Context, repoKey string, filePath
 // Security: Requires a privileged user (can be anonymous)
 func (s *ArtifactService) FileContents(ctx context.Context, repoKey string, filePath string, target interface{}) (*FileInfo, *http.Response, error) {
 	if target == nil {
-		return nil, nil, fmt.Errorf("Target is not allowed to be nil")
+		return nil, nil, fmt.Errorf("target is not allowed to be nil")
 	}
 
 	fileInfo, _, err := s.FileInfo(ctx, repoKey, filePath)

--- a/artifactory/v1/artifacts.go
+++ b/artifactory/v1/artifacts.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"github.com/atlassian/go-artifactory/v2/artifactory/client"
 )
 
 // ArtifactService exposes the Artifact API endpoints from Artifactory
@@ -216,7 +215,7 @@ func (s *ArtifactService) FileInfo(ctx context.Context, repoKey string, filePath
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", client.MediaTypeJson)
+	req.Header.Set("Accept", mediaTypeFileInfo)
 
 	fileInfo := new(FileInfo)
 	resp, err := s.client.Do(ctx, req, fileInfo)

--- a/artifactory/v1/artifacts.go
+++ b/artifactory/v1/artifacts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"github.com/atlassian/go-artifactory/v2/artifactory/client"
 )
 
 // ArtifactService exposes the Artifact API endpoints from Artifactory
@@ -182,4 +183,64 @@ func (s *ArtifactService) DeleteRepositoryReplicationConfig(ctx context.Context,
 		return nil, err
 	}
 	return s.client.Do(ctx, req, nil)
+}
+
+type Checksums struct {
+	Md5                    *string             `json:"md5,omitempty"`
+	Sha1                   *string             `json:"sha1,omitempty"`
+	Sha256                 *string             `json:"sha256,omitempty"`
+}
+
+type FileInfo struct {
+	Repo                   *string             `json:"repo,omitempty"`
+	Path                   *string             `json:"path,omitempty"`
+	Created                *string             `json:"created,omitempty"`
+	CreatedBy              *string             `json:"createdBy,omitempty"`
+	LastModified           *string             `json:"lastModified,omitempty"`
+	ModifiedBy             *string             `json:"modifiedBy,omitempty"`
+	LastUpdated            *string             `json:"lastUpdated,omitempty"`
+	DownloadUri            *string             `json:"downloadUri,omitempty"`
+	MimeType               *string             `json:"mimeType,omitempty"`
+	Size                   *int                `json:"size,string,omitempty"`
+	Checksums              *Checksums          `json:"checksums,omitempty"`
+	OriginalChecksums      *Checksums          `json:"originalChecksums,omitempty"`
+	Uri                    *string             `json:"uri,omitempty"`
+}
+
+// Description: Returns the metadata of the given file. Supported by local, local-cached and virtual repositories.
+// Security: Requires a privileged user (can be anonymous)
+func (s *ArtifactService) FileInfo(ctx context.Context, repoKey string, filePath string) (*FileInfo, *http.Response, error) {
+	path := fmt.Sprintf("/api/storage/%s/%s", repoKey, filePath)
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", client.MediaTypeJson)
+
+	fileInfo := new(FileInfo)
+	resp, err := s.client.Do(ctx, req, fileInfo)
+	return fileInfo, resp, err
+}
+
+// Description: Copies the specified file to the given target. Supported by local, local-cached and virtual repositories.
+// Security: Requires a privileged user (can be anonymous)
+func (s *ArtifactService) FileContents(ctx context.Context, repoKey string, filePath string, target interface{}) (*FileInfo, *http.Response, error) {
+	if target == nil {
+		return nil, nil, fmt.Errorf("Target is not allowed to be nil")
+	}
+
+	fileInfo, _, err := s.FileInfo(ctx, repoKey, filePath)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("GET", *fileInfo.DownloadUri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(ctx, req, target)
+	return fileInfo, resp, err
 }

--- a/artifactory/v1/artifacts_test.go
+++ b/artifactory/v1/artifacts_test.go
@@ -1,0 +1,100 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/atlassian/go-artifactory/v2/artifactory/client"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"bytes"
+	"strings"
+)
+
+func TestFileInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/storage/arbitrary-repository/path/to/an/existing/artifact", r.RequestURI)
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+    	
+		dummyRes := `{
+  "repo" : "arbitrary-repository",
+  "path" : "/path/to/an/existing/artifact",
+  "created" : "2019-10-22T07:12:08.538+02:00",
+  "createdBy" : "jondoe",
+  "lastModified" : "2019-10-22T09:38:55.713+02:00",
+  "modifiedBy" : "janedoe",
+  "lastUpdated" : "2019-10-22T09:38:55.731+02:00",
+  "downloadUri" : "http://%s/arbitrary-repository/path/to/an/existing/artifact",
+  "mimeType" : "application/zip",
+  "size" : "13400",
+  "checksums" : {
+    "sha1" : "1bc68542d65869e38eece7cfb1b038104ba7a5fb",
+    "md5" : "ccb552c5b0714ced4852c8d696da3387",
+    "sha256" : "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9"
+  },
+  "originalChecksums" : {
+    "sha1" : "1bc68542d65869e38eece7cfb1b038104ba7a5fb",
+    "md5" : "ccb552c5b0714ced4852c8d696da3387",
+    "sha256" : "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9"
+  },
+  "uri" : "%s"
+}`
+
+		_, _ = fmt.Fprint(w, fmt.Sprintf(dummyRes, r.Host, r.RequestURI))
+	}))
+
+	c, _ := client.NewClient(server.URL, http.DefaultClient);
+	v := NewV1(c);
+
+	fileInfo, _, err := v.Artifacts.FileInfo(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact");
+	assert.Nil(t, err)
+
+	assert.Equal(t, "arbitrary-repository",                      *fileInfo.Repo)
+	assert.Equal(t, "/path/to/an/existing/artifact",             *fileInfo.Path)
+	assert.Equal(t, "2019-10-22T07:12:08.538+02:00",             *fileInfo.Created)
+	assert.Equal(t, "jondoe",                                    *fileInfo.CreatedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.713+02:00",             *fileInfo.LastModified)
+	assert.Equal(t, "janedoe",                                   *fileInfo.ModifiedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.731+02:00",             *fileInfo.LastUpdated)
+	assert.Equal(t, fmt.Sprintf("%s/arbitrary-repository/path/to/an/existing/artifact", server.URL), *fileInfo.DownloadUri)
+	assert.Equal(t, "application/zip",                           *fileInfo.MimeType)
+	assert.Equal(t, 13400,                                       *fileInfo.Size)
+	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb",  *fileInfo.Checksums.Sha1)
+	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb",  *fileInfo.OriginalChecksums.Sha1)
+	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387",          *fileInfo.Checksums.Md5)
+	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387",          *fileInfo.OriginalChecksums.Md5)
+	assert.Equal(t, "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9", *fileInfo.Checksums.Sha256)
+	assert.Equal(t, "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9", *fileInfo.OriginalChecksums.Sha256)
+	assert.Equal(t, "/api/storage/arbitrary-repository/path/to/an/existing/artifact", *fileInfo.Uri)
+}
+
+func TestFileContents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		res := ""
+
+		if strings.HasSuffix(r.RequestURI, "/content") {
+			w.Header().Set("Content-Type", "text/plain")
+			res = "dummy content"
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+
+			res = fmt.Sprintf(`{ "downloadUri" : "http://%s%s/content" }`, r.Host, r.RequestURI)
+		}
+
+		_, _ = fmt.Fprint(w, res)
+	}))
+
+	c, _ := client.NewClient(server.URL, http.DefaultClient);
+	v := NewV1(c);
+
+	target := bytes.NewBufferString("")
+	fileInfo, _, err := v.Artifacts.FileContents(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact", target);
+
+	assert.Equal(t, "dummy content", target.String())
+	assert.NotNil(t, fileInfo)
+	assert.Nil(t, err)
+}

--- a/artifactory/v1/types.go
+++ b/artifactory/v1/types.go
@@ -16,6 +16,7 @@ const (
 	mediaTypePermissionTarget  = "application/vnd.org.jfrog.artifactory.security.PermissionTarget+json"
 	mediaTypeItemPermissions   = "application/vnd.org.jfrog.artifactory.storage.ItemPermissions+json"
 	mediaTypeReplicationConfig = "application/vnd.org.jfrog.artifactory.replications.ReplicationConfigRequest+json"
+	mediaTypeFileInfo          = "application/vnd.org.jfrog.artifactory.storage.FileInfo+json"
 )
 
 type Service struct {


### PR DESCRIPTION
With this PR I'm adding support for the _FileInfo_ endpoint. Furthermore there's now a _FileContents_ function that can be used to download files stored in the artifactory.

Reason is, that we'd like to extend the artifactory terraform provider.
https://github.com/atlassian/terraform-provider-artifactory/issues/63

Please let me know if you do have further questions.

Best,
Christian