### PR TITLE
Add ResolveDockerTagsByTimestamp to VirtualRepository model

### DIFF
--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -319,6 +319,7 @@ type VirtualRepository struct {
 	PomRepositoryReferencesCleanupPolicy          *string   `json:"pomRepositoryReferencesCleanupPolicy,omitempty"`
 	Repositories                                  *[]string `json:"repositories,omitempty"`
 	VirtualRetrievalCachePeriodSecs               *int      `json:"virtualRetrievalCachePeriodSecs,omitempty"`
+	ResolveDockerTagsByTimestamp                  *bool     `json:"resolveDockerTagsByTimestamp,omitempty"`
 }
 
 func (r VirtualRepository) String() string {


### PR DESCRIPTION
# What 
Add ResolveDockerTagsByTimestamp to VirtualRepository model

# Why
So the ResolveDockerTagsByTimestamp flag can be set using the go-artifactory client.

# References
- Resolves #21 
- [Artifactory release notes](https://www.jfrog.com/confluence/display/RTF/Release+Notes#ReleaseNotes-PullLatestDockerImagefromVirtualRepository)
- [Artifactory virtual repository API reference](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON#RepositoryConfigurationJSON-VirtualRepository)