### PR TITLE
Add FolderInfo support

### DIFF
--- a/artifactory/v1/artifacts.go
+++ b/artifactory/v1/artifacts.go
@@ -185,25 +185,25 @@ func (s *ArtifactService) DeleteRepositoryReplicationConfig(ctx context.Context,
 }
 
 type Checksums struct {
-	Md5                    *string             `json:"md5,omitempty"`
-	Sha1                   *string             `json:"sha1,omitempty"`
-	Sha256                 *string             `json:"sha256,omitempty"`
+	Md5    *string `json:"md5,omitempty"`
+	Sha1   *string `json:"sha1,omitempty"`
+	Sha256 *string `json:"sha256,omitempty"`
 }
 
 type FileInfo struct {
-	Repo                   *string             `json:"repo,omitempty"`
-	Path                   *string             `json:"path,omitempty"`
-	Created                *string             `json:"created,omitempty"`
-	CreatedBy              *string             `json:"createdBy,omitempty"`
-	LastModified           *string             `json:"lastModified,omitempty"`
-	ModifiedBy             *string             `json:"modifiedBy,omitempty"`
-	LastUpdated            *string             `json:"lastUpdated,omitempty"`
-	DownloadUri            *string             `json:"downloadUri,omitempty"`
-	MimeType               *string             `json:"mimeType,omitempty"`
-	Size                   *int                `json:"size,string,omitempty"`
-	Checksums              *Checksums          `json:"checksums,omitempty"`
-	OriginalChecksums      *Checksums          `json:"originalChecksums,omitempty"`
-	Uri                    *string             `json:"uri,omitempty"`
+	Repo              *string    `json:"repo,omitempty"`
+	Path              *string    `json:"path,omitempty"`
+	Created           *string    `json:"created,omitempty"`
+	CreatedBy         *string    `json:"createdBy,omitempty"`
+	LastModified      *string    `json:"lastModified,omitempty"`
+	ModifiedBy        *string    `json:"modifiedBy,omitempty"`
+	LastUpdated       *string    `json:"lastUpdated,omitempty"`
+	DownloadUri       *string    `json:"downloadUri,omitempty"`
+	MimeType          *string    `json:"mimeType,omitempty"`
+	Size              *int       `json:"size,string,omitempty"`
+	Checksums         *Checksums `json:"checksums,omitempty"`
+	OriginalChecksums *Checksums `json:"originalChecksums,omitempty"`
+	Uri               *string    `json:"uri,omitempty"`
 }
 
 // Description: Returns the metadata of the given file. Supported by local, local-cached and virtual repositories.
@@ -220,6 +220,39 @@ func (s *ArtifactService) FileInfo(ctx context.Context, repoKey string, filePath
 	fileInfo := new(FileInfo)
 	resp, err := s.client.Do(ctx, req, fileInfo)
 	return fileInfo, resp, err
+}
+
+type FolderInfoChild struct {
+	Uri    *string `json:"uri,omitempty"`
+	Folder *bool   `json:"folder,omitempty"`
+}
+
+type FolderInfo struct {
+	Repo         *string            `json:"repo,omitempty"`
+	Path         *string            `json:"path,omitempty"`
+	Created      *string            `json:"created,omitempty"`
+	CreatedBy    *string            `json:"createdBy,omitempty"`
+	LastModified *string            `json:"lastModified,omitempty"`
+	ModifiedBy   *string            `json:"modifiedBy,omitempty"`
+	LastUpdated  *string            `json:"lastUpdated,omitempty"`
+	Uri          *string            `json:"uri,omitempty"`
+	Children     []*FolderInfoChild `json:"children,omitempty"`
+}
+
+// Description: Returns the metadata of the given folder. Supported by local, local-cached and virtual repositories.
+// Security: Requires a privileged user (can be anonymous)
+func (s *ArtifactService) FolderInfo(ctx context.Context, repoKey string, folderPath string) (*FolderInfo, *http.Response, error) {
+	path := fmt.Sprintf("/api/storage/%s/%s", repoKey, folderPath)
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", mediaTypeFolderInfo)
+
+	folderInfo := new(FolderInfo)
+	resp, err := s.client.Do(ctx, req, folderInfo)
+	return folderInfo, resp, err
 }
 
 // Description: Copies the specified file to the given target. Supported by local, local-cached and virtual repositories.

--- a/artifactory/v1/artifacts_test.go
+++ b/artifactory/v1/artifacts_test.go
@@ -1,15 +1,15 @@
 package v1
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"github.com/atlassian/go-artifactory/v2/artifactory/client"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
-	"testing"
-	"bytes"
 	"strings"
+	"testing"
 )
 
 func TestFileInfo(t *testing.T) {
@@ -18,7 +18,7 @@ func TestFileInfo(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
-    	
+
 		dummyRes := `{
   "repo" : "arbitrary-repository",
   "path" : "/path/to/an/existing/artifact",
@@ -46,29 +46,77 @@ func TestFileInfo(t *testing.T) {
 		_, _ = fmt.Fprint(w, fmt.Sprintf(dummyRes, r.Host, r.RequestURI))
 	}))
 
-	c, _ := client.NewClient(server.URL, http.DefaultClient);
-	v := NewV1(c);
+	c, _ := client.NewClient(server.URL, http.DefaultClient)
+	v := NewV1(c)
 
-	fileInfo, _, err := v.Artifacts.FileInfo(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact");
+	fileInfo, _, err := v.Artifacts.FileInfo(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact")
 	assert.Nil(t, err)
 
-	assert.Equal(t, "arbitrary-repository",                      *fileInfo.Repo)
-	assert.Equal(t, "/path/to/an/existing/artifact",             *fileInfo.Path)
-	assert.Equal(t, "2019-10-22T07:12:08.538+02:00",             *fileInfo.Created)
-	assert.Equal(t, "jondoe",                                    *fileInfo.CreatedBy)
-	assert.Equal(t, "2019-10-22T09:38:55.713+02:00",             *fileInfo.LastModified)
-	assert.Equal(t, "janedoe",                                   *fileInfo.ModifiedBy)
-	assert.Equal(t, "2019-10-22T09:38:55.731+02:00",             *fileInfo.LastUpdated)
+	assert.Equal(t, "arbitrary-repository", *fileInfo.Repo)
+	assert.Equal(t, "/path/to/an/existing/artifact", *fileInfo.Path)
+	assert.Equal(t, "2019-10-22T07:12:08.538+02:00", *fileInfo.Created)
+	assert.Equal(t, "jondoe", *fileInfo.CreatedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.713+02:00", *fileInfo.LastModified)
+	assert.Equal(t, "janedoe", *fileInfo.ModifiedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.731+02:00", *fileInfo.LastUpdated)
 	assert.Equal(t, fmt.Sprintf("%s/arbitrary-repository/path/to/an/existing/artifact", server.URL), *fileInfo.DownloadUri)
-	assert.Equal(t, "application/zip",                           *fileInfo.MimeType)
-	assert.Equal(t, 13400,                                       *fileInfo.Size)
-	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb",  *fileInfo.Checksums.Sha1)
-	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb",  *fileInfo.OriginalChecksums.Sha1)
-	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387",          *fileInfo.Checksums.Md5)
-	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387",          *fileInfo.OriginalChecksums.Md5)
+	assert.Equal(t, "application/zip", *fileInfo.MimeType)
+	assert.Equal(t, 13400, *fileInfo.Size)
+	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb", *fileInfo.Checksums.Sha1)
+	assert.Equal(t, "1bc68542d65869e38eece7cfb1b038104ba7a5fb", *fileInfo.OriginalChecksums.Sha1)
+	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387", *fileInfo.Checksums.Md5)
+	assert.Equal(t, "ccb552c5b0714ced4852c8d696da3387", *fileInfo.OriginalChecksums.Md5)
 	assert.Equal(t, "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9", *fileInfo.Checksums.Sha256)
 	assert.Equal(t, "3a4d369251cdd78d616873e1eb7352f83997949969b020397fabc6e2d18801b9", *fileInfo.OriginalChecksums.Sha256)
 	assert.Equal(t, "/api/storage/arbitrary-repository/path/to/an/existing/artifact", *fileInfo.Uri)
+}
+
+func TestFolderInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/storage/arbitrary-repository/path/to/an/existing/folder", r.RequestURI)
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+
+		dummyRes := `{
+  "repo" : "arbitrary-repository",
+  "path" : "/path/to/an/existing/folder",
+  "created" : "2019-10-22T07:12:08.538+02:00",
+  "createdBy" : "jondoe",
+  "lastModified" : "2019-10-22T09:38:55.713+02:00",
+  "modifiedBy" : "janedoe",
+  "lastUpdated" : "2019-10-22T09:38:55.731+02:00",
+  "uri" : "%s",
+  "children": [{
+	"uri" : "/child1",
+	"folder" : true
+  },{
+	"uri" : "/child2",
+	"folder" : false
+  }]
+}`
+		_, _ = fmt.Fprint(w, fmt.Sprintf(dummyRes, r.RequestURI))
+	}))
+
+	c, _ := client.NewClient(server.URL, http.DefaultClient)
+	v := NewV1(c)
+
+	folderInfo, _, err := v.Artifacts.FolderInfo(context.Background(), "arbitrary-repository", "/path/to/an/existing/folder")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "arbitrary-repository", *folderInfo.Repo)
+	assert.Equal(t, "/path/to/an/existing/folder", *folderInfo.Path)
+	assert.Equal(t, "2019-10-22T07:12:08.538+02:00", *folderInfo.Created)
+	assert.Equal(t, "jondoe", *folderInfo.CreatedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.713+02:00", *folderInfo.LastModified)
+	assert.Equal(t, "janedoe", *folderInfo.ModifiedBy)
+	assert.Equal(t, "2019-10-22T09:38:55.731+02:00", *folderInfo.LastUpdated)
+	assert.Equal(t, "/api/storage/arbitrary-repository/path/to/an/existing/folder", *folderInfo.Uri)
+	assert.Len(t, folderInfo.Children, 2)
+	assert.Equal(t, "/child1", *folderInfo.Children[0].Uri)
+	assert.Equal(t, true, *folderInfo.Children[0].Folder)
+	assert.Equal(t, "/child2", *folderInfo.Children[1].Uri)
+	assert.Equal(t, false, *folderInfo.Children[1].Folder)
 }
 
 func TestFileContents(t *testing.T) {
@@ -88,11 +136,11 @@ func TestFileContents(t *testing.T) {
 		_, _ = fmt.Fprint(w, res)
 	}))
 
-	c, _ := client.NewClient(server.URL, http.DefaultClient);
-	v := NewV1(c);
+	c, _ := client.NewClient(server.URL, http.DefaultClient)
+	v := NewV1(c)
 
 	target := bytes.NewBufferString("")
-	fileInfo, _, err := v.Artifacts.FileContents(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact", target);
+	fileInfo, _, err := v.Artifacts.FileContents(context.Background(), "arbitrary-repository", "/path/to/an/existing/artifact", target)
 
 	assert.Equal(t, "dummy content", target.String())
 	assert.NotNil(t, fileInfo)

--- a/artifactory/v1/types.go
+++ b/artifactory/v1/types.go
@@ -17,6 +17,7 @@ const (
 	mediaTypeItemPermissions   = "application/vnd.org.jfrog.artifactory.storage.ItemPermissions+json"
 	mediaTypeReplicationConfig = "application/vnd.org.jfrog.artifactory.replications.ReplicationConfigRequest+json"
 	mediaTypeFileInfo          = "application/vnd.org.jfrog.artifactory.storage.FileInfo+json"
+	mediaTypeFolderInfo        = "application/vnd.org.jfrog.artifactory.storage.FolderInfo+json"
 )
 
 type Service struct {


### PR DESCRIPTION
Adds support for [FolderInfo](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-FolderInfo) queries, similar to the existing FileInfo support.
