### PR TITLE
Fix virtual repository key pair attribute

### DIFF
--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -315,7 +315,7 @@ type VirtualRepository struct {
 	EnableVagrantSupport                          *bool     `json:"enableVagrantSupport,omitempty"`
 	ExternalDependenciesEnabled                   *bool     `json:"externalDependenciesEnabled,omitempty"`
 	ForceNugetAuthentication                      *bool     `json:"forceNugetAuthentication,omitempty"`
-	KeyPair                                       *string   `json:"keyPair,omitempty"`
+	KeyPair                                       *string   `json:"keyPairRef,omitempty"`
 	PomRepositoryReferencesCleanupPolicy          *string   `json:"pomRepositoryReferencesCleanupPolicy,omitempty"`
 	Repositories                                  *[]string `json:"repositories,omitempty"`
 	VirtualRetrievalCachePeriodSecs               *int      `json:"virtualRetrievalCachePeriodSecs,omitempty"`


### PR DESCRIPTION
According to https://www.jfrog.com/confluence/display/JFROG/Repository+Configuration+JSON#RepositoryConfigurationJSON-VirtualRepository
the attribute to use to configure the key pair is `keyPairRef`