### PR TITLE
Add support for cargo repositories

### DIFF
--- a/artifactory/v1/repositories.go
+++ b/artifactory/v1/repositories.go
@@ -57,6 +57,7 @@ type LocalRepository struct {
 	BlackedOut                   *bool     `json:"blackedOut,omitempty"`
 	BlockXrayUnscannedArtifacts  *bool     `json:"blockXrayUnscannedArtifacts,omitempty"`
 	CalculateYumMetadata         *bool     `json:"calculateYumMetadata,omitempty"`
+	CargoAnonymousAccess         *bool     `json:"cargoAnonymousAccess"`
 	ChecksumPolicyType           *string   `json:"checksumPolicyType,omitempty"`
 	DebianTrivialLayout          *bool     `json:"debianTrivialLayout,omitempty"`
 	DockerApiVersion             *string   `json:"dockerApiVersion,omitempty"`
@@ -239,6 +240,9 @@ type RemoteRepository struct {
 	FeedContextPath     *string `json:"feedContextPath,omitempty"`
 	DownloadContextPath *string `json:"downloadContextPath,omitempty"`
 	V3FeedUrl           *string `json:"v3FeedUrl,omitempty"`
+
+	CargoAnonymousAccess *bool   `json:"cargoAnonymousAccess"`
+	GitRegistryUrl       *string `json:"gitRegistryUrl"`
 }
 
 func (r RemoteRepository) String() string {


### PR DESCRIPTION
JFrog added support for Rust Cargo repositories in Artifactory 7.17.4.

This PR adds handling to the local/remote repositories for cargo repos. (There is no virtual repository concept for cargo)

Git repository url is the remote cargo index url https://www.jfrog.com/confluence/display/JFROG/Cargo+Registry#CargoRegistry-RemoteRepositories
